### PR TITLE
fix: add exports.types

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   "exports": {
     ".": {
       "import": "./dist/index.mjs",
-      "require": "./dist/index.cjs"
+      "require": "./dist/index.cjs",
+      "types": "./dist/index.d.ts"
     }
   },
   "main": "./dist/index.cjs",


### PR DESCRIPTION
![image](https://github.com/QuiiBz/detect-runtime/assets/43268759/e54a0816-456a-49ac-81fd-e61732aae694)
