### PR TITLE
fix: exports.types order

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,9 +10,9 @@
   "type": "module",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
-      "require": "./dist/index.cjs",
-      "types": "./dist/index.d.ts"
+      "require": "./dist/index.cjs"
     }
   },
   "main": "./dist/index.cjs",


### PR DESCRIPTION
![image](https://github.com/QuiiBz/detect-runtime/assets/43268759/df57a92a-fcee-4505-9d67-2b0cf559ee8a)
