### PR TITLE
feat: add `fastly` Runtime Key

### DIFF
--- a/src/detect.ts
+++ b/src/detect.ts
@@ -18,6 +18,7 @@ import {
  * - `node` Node.js
  * - `bun` Bun
  * - `edge-light` Vercel Edge Functions
+ * - `fastly` Fastly Compute@Edge
  *
  * @see https://runtime-keys.proposal.wintercg.org/
  * @returns {Runtime}
@@ -49,6 +50,10 @@ export function detectRuntime(): Runtime {
 
   if (globalThis.Bun) {
     return "bun";
+  }
+
+  if (globalThis.fastly) {
+    return "fastly";
   }
 
   // TODO: Find a way to detect edge-routine

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,6 +10,8 @@ declare global {
   var Deno: any;
 
   var __lagon__: any;
+
+  var fastly: any;
 }
 
 // Follows the list of Runtime Keys from the WinterCG proposal:
@@ -25,4 +27,5 @@ export type Runtime =
   | "node"
   | "bun"
   | "edge-light"
+  | "fastly"
   | "unknown";


### PR DESCRIPTION
Fastly Compute@Edge will probably soon be added to the Runtime Keys proposal, as `fastly`: https://github.com/wintercg/runtime-keys/pull/6